### PR TITLE
[MEMO1.0-006]: アプリ名が正しくない。

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">メモ帳</string>
+    <string name="app_name">メーモ</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
 


### PR DESCRIPTION
**問題の原因**
String リソースの文字列リソースが「メモ帳」になっている

**対応内容**
Resourceにあるstrings.xmlのアプリ名を「メモ帳」から「メーモ」に変更

**Fixed File**
app/src/main/res/values/strings.xml

**コミット前動作確認**
１．端末を立ち上げる
２．該当アプリのアプリ名が「メーモ」となっている