### PR TITLE
[MEMO01-002]:テーマ画面のタイトルが「メモ帳」と表示されている。

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/theme/ThemeActivity.java
+++ b/app/src/main/java/com/example/e01_memo/ui/theme/ThemeActivity.java
@@ -33,7 +33,6 @@ public class ThemeActivity extends AppCompatActivity implements ThemeFragment.Th
 
         ThemeFragment fragment = ThemeFragment.newInstance(themeSetting.ordinal());
 
-
         presenter = new ThemePresenterImpl(fragment);
 
         getSupportFragmentManager().beginTransaction()

--- a/app/src/main/java/com/example/e01_memo/ui/theme/ThemeActivity.java
+++ b/app/src/main/java/com/example/e01_memo/ui/theme/ThemeActivity.java
@@ -29,9 +29,10 @@ public class ThemeActivity extends AppCompatActivity implements ThemeFragment.Th
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setHomeButtonEnabled(true);
 
+        setTitle(R.string.theme);
+
         ThemeFragment fragment = ThemeFragment.newInstance(themeSetting.ordinal());
 
-        setTitle("テーマ");
 
         presenter = new ThemePresenterImpl(fragment);
 

--- a/app/src/main/java/com/example/e01_memo/ui/theme/ThemeActivity.java
+++ b/app/src/main/java/com/example/e01_memo/ui/theme/ThemeActivity.java
@@ -31,6 +31,8 @@ public class ThemeActivity extends AppCompatActivity implements ThemeFragment.Th
 
         ThemeFragment fragment = ThemeFragment.newInstance(themeSetting.ordinal());
 
+        setTitle("テーマ");
+
         presenter = new ThemePresenterImpl(fragment);
 
         getSupportFragmentManager().beginTransaction()


### PR DESCRIPTION
**問題の原因**
アプリのテーマをセットしていない為

**対応内容**
ThemeActivity内でsetTitleメソッドを呼び出し、「テーマ」の文字をセット

**Fixed File**
app/src/main/java/com/example/e01_memo/ui/theme/ThemeActivity.java

**コミット前の動作確認**
１．アプリを立ち上げる
２．設定のアイコンをクリック
３．テーマをクリック
４．アプリバーの記述が「テーマ」になっていることを確認