### PR TITLE
[MEMO1.0-004]:新規メモ作成画面からバックボタンで前の画面に戻ると強制終了する。

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditActivity.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditActivity.java
@@ -302,6 +302,11 @@ public class EditActivity extends AppCompatActivity implements EditFragment.Edit
     }
 
     @Override
+    public View getCurrentFocusView() {
+        return getCurrentFocus();
+    }
+
+    @Override
     public void onBackPressed() {
         if (presenter != null) presenter.onUpdateMemo();
     }

--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -159,12 +159,13 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
     public void hideSoftKeyboard() {
 
         if(editActionListener == null) {
-            Log.d(editActionListener.getClass().getSimpleName(), "リスナーがNULLです。");
+            Log.e(editActionListener.getClass().getSimpleName(), "EditActionListener not implemented");
             return;
-        } else {
-            View focusView = editActionListener.getCurrentFocusView();
-            inputMethodManager.hideSoftInputFromWindow(focusView.getWindowToken(), 0);
         }
+
+        View focusView = editActionListener.getCurrentFocusView();
+        inputMethodManager.hideSoftInputFromWindow(focusView.getWindowToken(), 0);
+
     }
 
     @Override

--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -155,7 +155,16 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
 
     @Override
     public void hideSoftKeyboard() {
-        inputMethodManager.hideSoftInputFromWindow(getActivity().getWindow().getCurrentFocus().getWindowToken(), 0);
+
+        //画面のフォーカスを取得する
+        View forcusView = getActivity().getCurrentFocus();
+
+        //もしどこもフォーカスしていなかったらEditTextを指定する
+        if(forcusView == null) {
+            forcusView = editText;
+        }
+        
+        inputMethodManager.hideSoftInputFromWindow(forcusView.getWindowToken(), 0);
     }
 
     @Override

--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -14,6 +14,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -157,15 +158,13 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
     @Override
     public void hideSoftKeyboard() {
 
-        //EditActivityのフォーカスビューを取得
-        View focusView = editActionListener.getCurrentFocusView();
-
-        //もしどこもフォーカスしていなかったらEditTextを指定する
-        if(focusView == null) {
-            focusView = editText;
+        if(editActionListener == null) {
+            Log.d(editActionListener.getClass().getSimpleName(), "リスナーがNULLです。");
+            return;
+        } else {
+            View focusView = editActionListener.getCurrentFocusView();
+            inputMethodManager.hideSoftInputFromWindow(focusView.getWindowToken(), 0);
         }
-
-        inputMethodManager.hideSoftInputFromWindow(focusView.getWindowToken(), 0);
     }
 
     @Override

--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -54,6 +54,7 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
         void actionRequestWritePermission();
         void actionSaveAsImgComplete(File file);
         void showRestoreDialog(DialogInterface.OnClickListener listener);
+        View getCurrentFocusView();
     }
 
     public EditFragment() {}
@@ -156,14 +157,14 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
     @Override
     public void hideSoftKeyboard() {
 
-        //画面のフォーカスを取得する
-        View focusView = getActivity().getCurrentFocus();
+        //EditActivityのフォーカスビューを取得
+        View focusView = editActionListener.getCurrentFocusView();
 
         //もしどこもフォーカスしていなかったらEditTextを指定する
         if(focusView == null) {
             focusView = editText;
         }
-        
+
         inputMethodManager.hideSoftInputFromWindow(focusView.getWindowToken(), 0);
     }
 

--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -157,14 +157,14 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
     public void hideSoftKeyboard() {
 
         //画面のフォーカスを取得する
-        View forcusView = getActivity().getCurrentFocus();
+        View focusView = getActivity().getCurrentFocus();
 
         //もしどこもフォーカスしていなかったらEditTextを指定する
-        if(forcusView == null) {
-            forcusView = editText;
+        if(focusView == null) {
+            focusView = editText;
         }
         
-        inputMethodManager.hideSoftInputFromWindow(forcusView.getWindowToken(), 0);
+        inputMethodManager.hideSoftInputFromWindow(focusView.getWindowToken(), 0);
     }
 
     @Override


### PR DESCRIPTION
**問題の原因**
何も操作をしないで戻るボタンを押すと、フォーカスしておらずNullPointerExceptionが発生し、強制終了となっていた為。

**対応内容**
メモ画面を起動後、どこもフォーカスしないで戻るボタンを押すと、フォーカスがNullになってしまう。もし何も操作をせず戻るボタンを押下する場合は強制的にEditTextをフォーカスするように修正

**Fixed File**
app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java

**コミット前の動作確認**
1.アプリを立ち上げて、右下の鉛筆マークをクリック
2.左上の戻るボタンをクリックする
3.強制終了するすることなく戻ることができる