### PR TITLE
[Memo1.0-005]:メモに文字を入力できない。

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java
@@ -258,6 +258,7 @@ public class EditFragment extends BaseFragment implements EditContract.EditView,
 
 
     public void showSoftKeyboard() {
+        editText.requestFocus();
         inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED,InputMethodManager.HIDE_IMPLICIT_ONLY);
     }
 


### PR DESCRIPTION
**問題の原因**
メモ入力画面を起動した際は、入力欄にフォーカスされていないので、入力されても反映されない

**対応内容**
鉛筆アイコンをクリックした際に、メモ入力欄にフォーカスをあてるように修正

**Fixed File**
app/src/main/java/com/example/e01_memo/ui/edit/EditFragment.java

**コミット前の動作確認**
1.アプリを起動して、右下の鉛筆アイコンをクリックする
2.画面のキーボードを入力して、文字を入力できることを確認する。