### PR TITLE
[MEMO1.0-008]: ゴミ箱が空の場合の表示が正しくない。

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,7 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("空です");
+            emptyText.setText(R.string.not_delete_memo);
         }
     }
 


### PR DESCRIPTION
**問題の原因**
正しい文言ではない文字列を指定していた為

**対応内容**
リソースのString内から、正しい文言のデータをセットした

**Fixed File**
app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java

**コミット前の動作確認**
前提条件：メモを一つもない状態にする
１．アプリを立ち上げる
２．文言が「ゴミ箱にメモがありません」になっていること